### PR TITLE
Fix locale tests

### DIFF
--- a/tests/fixtures/locales.js
+++ b/tests/fixtures/locales.js
@@ -81,14 +81,14 @@ const supportedLocalesWithCurrency = [
     geo: 'sg',
     name: 'Singapore',
     expect: 'US$4.99/month + tax',
-    stageExpect: 'US$4.99/month + tax'
+    stageExpect: 'US$4.99/month'
   },
   {
     lang: 'en-US',
     geo: 'US',
     name: 'United States',
     expect: 'US$4.99/month + tax',
-    stageExpect: 'US$4.99/month'
+    stageExpect: 'US$4.99/month + tax'
   }
 ];
 

--- a/tests/fixtures/locales.js
+++ b/tests/fixtures/locales.js
@@ -3,91 +3,91 @@ const supportedLocalesWithCurrency = [
     lang: 'de',
     geo: 'at',
     name: 'Austria',
-    expect: 'US$4.99/Monat',
+    expect: 'US$4.99/Monat zzgl. Steuern',
     stageExpect: '4,99 €/Monat'
   }, // currently returns USD instead of EURO
   {
     lang: 'nl',
     geo: 'be',
     name: 'Belgium',
-    expect: 'US$4.99/maand',
+    expect: 'US$4.99/maand + BTW',
     stageExpect: '4,99 €/maand'
   },
   {
     lang: 'en-US',
     geo: 'ca',
     name: 'Canada',
-    expect: 'US$4.99/month',
-    stageExpect: 'US$4.99/month'
+    expect: 'US$4.99/month + tax',
+    stageExpect: 'US$4.99/month + tax'
   },
   {
     lang: 'de',
     geo: 'ch',
     name: 'Switzerland',
-    expect: 'US$4.99/Monat',
+    expect: 'US$4.99/Monat zzgl. Steuern',
     stageExpect: 'CHF 5.99/Monat'
   },
   {
     lang: 'de',
     geo: 'de',
     name: 'Germany',
-    expect: 'US$4.99/Monat',
+    expect: 'US$4.99/Monat zzgl. Steuern',
     stageExpect: '4,99 €/Monat'
   },
   {
     lang: 'es-US',
     geo: 'es',
     name: 'Spain',
-    expect: 'US$4.99/month',
-    stageExpect: '4,99 €/month'
+    expect: 'US$4.99/mes + impuestos',
+    stageExpect: '4,99 €/month'  // WTF?
   },
   {
     lang: 'fr',
     geo: 'fr',
     name: 'France',
-    expect: 'US$4.99/mois',
+    expect: 'US$4.99/mois + taxes',
     stageExpect: '4,99 €/mois'
   },
   {
     lang: 'en-US',
     geo: 'gb',
     name: 'UK',
-    expect: 'US$4.99/month',
+    expect: 'US$4.99/month + tax',
     stageExpect: 'US$4.99/month'
   }, // shouldn't this be in pounds?
   {
     lang: 'it',
     geo: 'it',
     name: 'Italy',
-    expect: 'US$4.99 al mese',
+    expect: 'US$4.99 al mese + tasse',
     stageExpect: '4,99 € al mese'
   },
   {
     lang: 'en-US',
     geo: 'my',
     name: 'Malaysia',
-    expect: 'US$4.99/month',
+    expect: 'US$4.99/month + tax',
     stageExpect: 'US$4.99/month'
   },
   {
     lang: 'en-US',
     geo: 'nz',
     name: 'New Zealand',
-    expect: 'US$4.99/month',
+    expect: 'US$4.99/month + tax',
     stageExpect: 'US$4.99/month'
   },
   {
     lang: 'en-US',
     geo: 'sg',
     name: 'Singapore',
-    expect: 'US$4.99/month',
-    stageExpect: 'US$4.99/month'
+    expect: 'US$4.99/month + tax',
+    stageExpect: 'US$4.99/month + tax'
   },
   {
     lang: 'en-US',
     geo: 'US',
     name: 'United States',
-    expect: 'US$4.99/month',
+    expect: 'US$4.99/month + tax',
     stageExpect: 'US$4.99/month'
   }
 ];

--- a/tests/fixtures/locales.js
+++ b/tests/fixtures/locales.js
@@ -5,7 +5,7 @@ const supportedLocalesWithCurrency = [
     name: 'Austria',
     expect: 'US$4.99/Monat zzgl. Steuern',
     stageExpect: '4,99 €/Monat'
-  }, // currently returns USD instead of EURO
+  },
   {
     lang: 'nl',
     geo: 'be',

--- a/tests/fixtures/locales.js
+++ b/tests/fixtures/locales.js
@@ -35,11 +35,11 @@ const supportedLocalesWithCurrency = [
     stageExpect: '4,99 €/Monat'
   },
   {
-    lang: 'es-US',
+    lang: 'es-ES',
     geo: 'es',
     name: 'Spain',
     expect: 'US$4.99/mes + impuestos',
-    stageExpect: '4,99 €/month'  // WTF?
+    stageExpect: '4,99 €/mes'
   },
   {
     lang: 'fr',
@@ -54,7 +54,7 @@ const supportedLocalesWithCurrency = [
     name: 'UK',
     expect: 'US$4.99/month + tax',
     stageExpect: 'US$4.99/month'
-  }, // shouldn't this be in pounds?
+  },
   {
     lang: 'it',
     geo: 'it',

--- a/tests/specs/guardian-localization-urls.spec.js
+++ b/tests/specs/guardian-localization-urls.spec.js
@@ -16,7 +16,6 @@ let urlForScenario = function(scenario, locale) {
   return urlString;
 }
 
-
 testScenarios.forEach((scenario) => {
   /**
     * C1538754 - Verify that 3 subscriptions plans are displayed

--- a/tests/specs/guardian-localization-urls.spec.js
+++ b/tests/specs/guardian-localization-urls.spec.js
@@ -7,7 +7,7 @@ const { testScenarios } = require('../fixtures/scenarios');
 let GuardianSpecs;
 test.describe.configure({ mode: 'parallel' });
 
-let urlForScenario = function(scenario, locale) {
+let urlForScenarioAndRegion = function(scenario, locale) {
   let baseURL = scenario.TEST_EXPECT_URL;
   let urlString = `${baseURL}/${locale.lang}/products/vpn/`;
   if (scenario.TEST_ENV === "stage") {
@@ -25,10 +25,10 @@ testScenarios.forEach((scenario) => {
     *
     * These tests make assertions about the values of localized strings in
     * various regions and locales. It is important to note that on stage, it is
-    * possible to simulate the experience a user will have in a different
-    * region by setting the `geo` URL query parameter. For the purpose of these
-    * tests, this affects the currency displayed to the user, while the locale
-    * (set in the URL itself) changes the displayed language.
+    * possible to simulate the page a user will see in a different region by
+    * setting the `geo` URL query parameter. For the purpose of these tests,
+    * this affects the currency displayed to the user, while the locale (set in
+    * the URL itself) changes the displayed language.
     *
     * Setting the `geo` parameter has no effect on production (see
     * https://github.com/mozilla/bedrock/issues/12967#issuecomment-1498694421)
@@ -48,14 +48,14 @@ testScenarios.forEach((scenario) => {
 
       for (const locale of supportedLocalesWithCurrency) {
         test.describe(
-          `${locale.name} - ${urlForScenario(scenario, locale)}`,
+          `${locale.name} - ${urlForScenarioAndRegion(scenario, locale)}`,
           () => {
             test.beforeEach(async ({ page }) => {
               allure.suite(
                 `${scenario.TEST_ENV} - Version: ${GuardianSpecs.version}, Commit: ${GuardianSpecs.commit}`
               );
               await page.goto(
-                urlForScenario(scenario, locale),
+                urlForScenarioAndRegion(scenario, locale),
                 {
                   waitUntil: 'networkidle'
                 }


### PR DESCRIPTION
Fixes VPN-4549

Update currency strings to reflect the fact that taxes are now being charged for users who live in the US and Canadian geographic regions.

Also added a few tweaks to the tests themselves, along with some documentation, to reflect that testing geographic region is not possible in prod due to Bedrock limitations.

Note that a few tests currently do not pass because the locale strings are incorrect. I have added comments or suggestions to the relevant Pontoon locale strings and suggest that we merge these with the tests failing while we wait for the Pontoon strings to be updated.

Pontoon strings:
- https://pontoon.mozilla.org/es-ES/mozillaorg/en/products/vpn/shared.ftl/?string=222533
- https://pontoon.mozilla.org/nl/mozillaorg/en/products/vpn/shared.ftl/?string=268334