### PR TITLE
Add a failing test to check Sentry config

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2,7 +2,7 @@ name: Scheduled Test and Publish
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 * * * *'
 
   workflow_dispatch:
 

--- a/tests/specs/guardian-basics-terms.spec.js
+++ b/tests/specs/guardian-basics-terms.spec.js
@@ -7,8 +7,13 @@ const { testScenarios } = require('../fixtures/scenarios');
 let GuardianSpecs;
 test.describe.configure({ mode: 'parallel' });
 
+test(`expected failure`, () => {
+  expect(true).toBe(false);
+});
+
 testScenarios.forEach((scenario) => {
   const baseUrl = scenario.TEST_EXPECT_URL;
+
 
   test.describe(`guardian basics ${scenario.TEST_ENV} - terms, C1538755`, () => {
     test.beforeAll(async () => {


### PR DESCRIPTION
This PR adds a failing test and updates the check rate to be once per hour to check the state of the Sentry config for e2e tests.

This will be reverted once we have tweaked the alerts to be to our liking.