### PR TITLE
Add `test.fail()` for failing Spanish locale test

### DIFF
--- a/tests/specs/guardian-localization-urls.spec.js
+++ b/tests/specs/guardian-localization-urls.spec.js
@@ -65,6 +65,10 @@ testScenarios.forEach((scenario) => {
             test(`Verify locale handling in ${locale.name}`, async ({
               page
             }) => {
+              test.fail(
+                scenario.TEST_ENV === "stage" && locale.lang === "es-ES",
+                "waiting on resolution for https://pontoon.mozilla.org/es-ES/mozillaorg/en/products/vpn/shared.ftl/?string=222533"
+              );
               const pricingTables = await page
                 .locator('#pricing .vpn-content-block')
                 .count();


### PR DESCRIPTION
Add a `test.fail()` call to prevent the Spanish locale tests from failing.

These failures are expected while we wait on a Pontoon string change.