### PR TITLE
Use axios for redirect test logic in place of Playwright

### DIFF
--- a/tests/specs/guardian-redirects.spec.js
+++ b/tests/specs/guardian-redirects.spec.js
@@ -32,32 +32,20 @@ testScenarios.forEach((scenario) => {
         expect(page.url()).toContain(givenExpectedUrl)
       })
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/invite, C1539666`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/invite, C1539666`, async () => {
         if (scenario.TEST_ENV === 'prod') {
           await verifyRedirectUrl(
-            page,
             `${baseUrl}/vpn/invite`,
             `${expectedBaseUrl}/en-US/products/vpn/invite/`
           );
         }
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/invite/success, C1539667`, async ({
-        page
-      }) => {
-        const givenBaseUrl =
-          scenario.TEST_ENV === 'stage'
-            ? `${baseUrl}/vpn/invite/success`
-            : `${baseUrl}/r/vpn/invite/success`;
+      test(`Verify redirect for ${baseUrl}/r/vpn/invite/success, C1539667`, async () => {
+        const givenBaseUrl = `${baseUrl}/vpn/invite/success`;
+        const expectedUrl = `${expectedBaseUrl}/en-US/products/vpn/invite/`;
 
-        const expectedUrl =
-          scenario.TEST_ENV === 'stage'
-            ? `${expectedBaseUrl}/en-US/products/vpn/invite/`
-            : `${baseUrl}/r/vpn/invite/success`;
-
-        await verifyRedirectUrl(page, givenBaseUrl, expectedUrl);
+        await verifyRedirectUrl(givenBaseUrl, expectedUrl);
       });
 
       test(`Verify redirect for ${baseUrl}/r/vpn/subscribe, C1539668`, async ({ page }) => {
@@ -93,16 +81,13 @@ testScenarios.forEach((scenario) => {
         }
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/account, C1539671`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/account, C1539671`, async () => {
         const givenExpectedUrl =
           scenario.TEST_ENV === 'stage'
             ? 'https://accounts.stage.mozaws.net/'
             : 'https://accounts.firefox.com/';
 
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/account`,
           givenExpectedUrl
         );
@@ -120,61 +105,49 @@ testScenarios.forEach((scenario) => {
         expect(page.url()).toContain(expectedUrl);
       })
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/support, C1539673`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/support, C1539673`, async () => {
         const prodRes = 'products/firefox-private-network-vpn'
         const stageRes = 'products/firefox-private-network-vpn'
 
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/support`,
           `https://support.mozilla.org/en-US/${scenario.TEST_ENV === 'stage' ? stageRes : prodRes}`
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/subscriptionBlocked, C1539674`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/subscriptionBlocked, C1539674`, async () => {
         const prodRes = 'products/firefox-private-network-vpn'
         const stageRes = 'products/firefox-private-network-vpn'
 
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/subscriptionBlocked`,
           `https://support.mozilla.org/en-US/${scenario.TEST_ENV === 'stage' ? stageRes : prodRes}`
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/contact, C1539675`, async ({ page }, testInfo) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/contact, C1539675`, async ({ page }) => {
         const expectedUrl = 'https://accounts.firefox.com/'
 
         await page.goto(`${baseUrl}/r/vpn/contact`, { waitUntil: 'networkidle' })
         await expect.poll(async () => {
           return page.url()
-            }, {
-              // wait at 2 sec in between
-              intervals: [2_000],
-              // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
-              timeout: 10000,
+        }, {
+          // wait at 2 sec in between
+          intervals: [2_000],
+          // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
+          timeout: 10000,
         }).toContain(expectedUrl);
       })
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/terms, C1539676`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/terms, C1539676`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/terms`,
           'https://www.mozilla.org/en-US/about/legal/terms/subscription-services/'
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/, C1539677`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/, C1539677`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/privacy`,
           'https://www.mozilla.org/en-US/privacy/subscription-services/'
         );
@@ -182,51 +155,36 @@ testScenarios.forEach((scenario) => {
     });
 
     test.describe('download redirects', () => {
-      test(`Verify redirect for ${baseUrl}/r/vpn/download/linux, C1539669`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/download/linux, C1539669`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/download/linux`,
           'https://support.mozilla.org/en-US/kb/how-install-mozilla-vpn-linux-computer'
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/update/linux, C1539669`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/update/linux, C1539669`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/update/linux`,
           'https://support.mozilla.org/en-US/kb/how-install-mozilla-vpn-linux-computer'
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/update/windows, C1539669`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/update/windows, C1539669`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/update/windows`,
           `${expectedBaseUrl}/en-US/products/vpn/download/`
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/update/ios, C1539669`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/update/ios, C1539669`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/update/ios`,
           'https://apps.apple.com/us/app/firefox-private-network-vpn/id1489407738'
         );
       });
 
-      test(`Verify redirect for ${baseUrl}/r/vpn/update/android, C1539669`, async ({
-        page
-      }) => {
+      test(`Verify redirect for ${baseUrl}/r/vpn/update/android, C1539669`, async () => {
         await verifyRedirectUrl(
-          page,
           `${baseUrl}/r/vpn/update/android`,
           'https://play.google.com/store/apps/details?id=org.mozilla.firefox.vpn'
         );

--- a/tests/utils/helpers.js
+++ b/tests/utils/helpers.js
@@ -4,13 +4,28 @@ const axios = require('axios');
 const verifyUrl = async (page, expectedUrl) =>
   expect(page.url()).toEqual(expectedUrl);
 
-const verifyRedirectUrl = async (page, baseUrl, expectedUrl) => {
-  await page.goto(baseUrl, { waitUntil: 'networkidle' });
-  expect(page.url()).toEqual(expectedUrl);
+// TODO doc
+const verifyRedirectUrl = async (base, expected, options) => {
+  options = Object.assign({
+    followRedirects: false,
+  }, options);
+
+  let redirectResult;
+  if (options.followRedirects === true) {
+    options = Object.assign({ status: 302 }, options);
+    redirectResult = await axios.get(base, { maxRedirects: 0, validateStatus: null });
+    expect(redirectResult.headers.location).toEqual(expected);
+  } else {
+    options = Object.assign({ status: 200 }, options);
+    redirectResult = await axios.get(base, { validateStatus: null });
+    expect(redirectResult.request.res.responseUrl).toEqual(expected);
+  }
+
+  expect(redirectResult.status).toEqual(options.status);
 };
 
 const delay = (timeInMilliSeconds) =>
-  new Promise(function (resolve) {
+  new Promise(function(resolve) {
     setTimeout(resolve, timeInMilliSeconds);
   });
 


### PR DESCRIPTION
Prerequisite for VPN-4547.

The original redirect tests were written using a call to a Playwright API, which is designed for loading HTML pages. This caused problems with running tests against redirects where the final HTTP request returned a binary file rather than HTML. The solution is to replace the Playwright call with a call to a standard node HTTP client (axios) which can halt the redirect process and check the Location header of the response.

The new call contains a switch that will prevent axios from following redirects. None of the existing tests use this switch, but it is a requirement for tests that will be written for VPN-4547.